### PR TITLE
import imread from scipy.ndimage instead of scipy.misc

### DIFF
--- a/mglearn/plot_animal_tree.py
+++ b/mglearn/plot_animal_tree.py
@@ -1,4 +1,4 @@
-from scipy.misc import imread
+from scipy.ndimage import imread
 import matplotlib.pyplot as plt
 
 

--- a/mglearn/plot_interactive_tree.py
+++ b/mglearn/plot_interactive_tree.py
@@ -5,7 +5,7 @@ from sklearn.tree import DecisionTreeClassifier
 
 from sklearn.externals.six import StringIO  # doctest: +SKIP
 from sklearn.tree import export_graphviz
-from scipy.misc import imread
+from scipy.ndimage import imread
 from scipy import ndimage
 from sklearn.datasets import make_moons
 


### PR DESCRIPTION
This gets a pip install'd Jupyter working well for figure 1-3's corresponding call grr = pd.scatter_matrix(...cmap = mglearn.cm3). It complains that it can't find imread otherwise for some reason.
