### PR TITLE
change current_cycler() to current_cycler

### DIFF
--- a/mglearn/plot_helpers.py
+++ b/mglearn/plot_helpers.py
@@ -77,7 +77,7 @@ def discrete_scatter(x1, x2, y=None, markers=None, s=10, ax=None,
 
     current_cycler = mpl.rcParams['axes.prop_cycle']
 
-    for i, (yy, cycle) in enumerate(zip(unique_y, current_cycler())):
+  for i, (yy, cycle) in enumerate(zip(unique_y, current_cycler)):
         mask = y == yy
         # if c is none, use color cycle
         if c is None:


### PR DESCRIPTION
Hi Andreas,

I was go this error when running your example in ch 2:
```
     78     current_cycler = mpl.rcParams['axes.prop_cycle']
     79 
---> 80     for i, (yy, cycle) in enumerate(zip(unique_y, current_cycler())):
     81         mask = y == yy
     82         # if c is none, use color cycle

TypeError: 'Cycler' object is not callable
```
the error was fixed when changing `current_cycler()` to `current_cycler` on line 81.

(I'm using Python 3.5 w/ matplotlib version: 1.5.3)