### PR TITLE
TypeError: 'Cycler' object is not callable

### DIFF
--- a/mglearn/plot_helpers.py
+++ b/mglearn/plot_helpers.py
@@ -77,7 +77,8 @@ def discrete_scatter(x1, x2, y=None, markers=None, s=10, ax=None,
 
     current_cycler = mpl.rcParams['axes.prop_cycle']
 
-    for i, (yy, cycle) in enumerate(zip(unique_y, current_cycler())):
+    for i, (yy, cycle) in enumerate(zip(unique_y, current_cycler)):
+#initially for i, (yy, cycle) in enumerate(zip(unique_y, current_cycler())):      
         mask = y == yy
         # if c is none, use color cycle
         if c is None:


### PR DESCRIPTION
I went through your example chap 2 using make_forge dataset, and I experienced this TypeError : 
TypeError: 'Cycler' object is not callable 

I'm currently using 
In [2]: print("Python version: {}".format(sys.version))
Python version: 2.7.12 (default, Nov 19 2016, 06:48:10) 
[GCC 5.4.0 20160609]

In your book you're using a 3.5.2 version. This could explain the error I experienced but I preferred mentioning it, just in case 
