### PR TITLE
updated deprecated imports - scipy.imread() to imageio.imread()

### DIFF
--- a/mglearn/plot_animal_tree.py
+++ b/mglearn/plot_animal_tree.py
@@ -1,4 +1,4 @@
-from scipy.misc import imread
+from imageio import imread
 import matplotlib.pyplot as plt
 
 

--- a/mglearn/plot_interactive_tree.py
+++ b/mglearn/plot_interactive_tree.py
@@ -5,7 +5,7 @@ from sklearn.tree import DecisionTreeClassifier
 
 from sklearn.externals.six import StringIO  # doctest: +SKIP
 from sklearn.tree import export_graphviz
-from scipy.misc import imread
+from imageio import imread
 from scipy import ndimage
 from sklearn.datasets import make_moons
 


### PR DESCRIPTION
imread() is deprecated according to the scipy docs see link below. imageio.imread() is the preferred solution.

https://docs.scipy.org/doc/scipy/reference/generated/scipy.misc.imread.html