### PR TITLE
Create .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 group: travis_latest 
 language: python
 cache: pip
+python:
+  - 2.7
+  - 3.6
+matrix:
+  allow_failures:
+    - python: 2.7
 env:
   - NOTEBOOK=01-introduction.ipynb
   - NOTEBOOK=02-supervised-learning.ipynb
@@ -10,17 +16,6 @@ env:
   - NOTEBOOK=06-algorithm-chains-and-pipelines.ipynb
   - NOTEBOOK=07-working-with-text-data.ipynb
   - NOTEBOOK=08-conclusion.ipynb
-  matrix:
-    allow_failures:
-      - python: 2.7
-    include:
-      - python: 2.7
-      #- python: 3.4
-      #- python: 3.5
-      #- python: 3.6
-      - python: 3.7
-        dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
-        sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
 install:
   # - pip install -r requirements.txt
   - pip install flake8 jupyter

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
 group: travis_latest 
 language: python
 cache: pip
-env:
-  - NOTEBOOK=01-introduction.ipynb
-  - NOTEBOOK=02-supervised-learning.ipynb
-  - NOTEBOOK=03-unsupervised-learning.ipynb
-  - NOTEBOOK=04-representing-data-feature-engineering.ipynb
-  - NOTEBOOK=05-model-evaluation-and-improvement.ipynb
-  - NOTEBOOK=06-algorithm-chains-and-pipelines.ipynb
-  - NOTEBOOK=07-working-with-text-data.ipynb
-  - NOTEBOOK=08-conclusion.ipynb
 matrix:
+  env:
+    - NOTEBOOK=01-introduction.ipynb
+    - NOTEBOOK=02-supervised-learning.ipynb
+    - NOTEBOOK=03-unsupervised-learning.ipynb
+    - NOTEBOOK=04-representing-data-feature-engineering.ipynb
+    - NOTEBOOK=05-model-evaluation-and-improvement.ipynb
+    - NOTEBOOK=06-algorithm-chains-and-pipelines.ipynb
+    - NOTEBOOK=07-working-with-text-data.ipynb
+    - NOTEBOOK=08-conclusion.ipynb
   allow_failures:
     - python: 2.7
   include:
@@ -30,7 +30,8 @@ before_script:
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
-  - jupyter nbconvert ${NOTEBOOK} --stdout --to script | flake8 - --ignore=W391
+  - jupyter nbconvert ${NOTEBOOK} --stdout --to script | flake8 - --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  - jupyter nbconvert ${NOTEBOOK} --stdout --to script | flake8 - --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 notifications:
   on_success: change
   on_failure: change  # `always` will be the setting once code changes slow down

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,16 @@ before_script:
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
-  - jupyter nbconvert ${NOTEBOOK} --stdout --to script | flake8 - --count --select=E901,E999,F821,F822,F823 --show-source --statistics
-  - jupyter nbconvert ${NOTEBOOK} --stdout --to script | flake8 - --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - |
+    (cat << EOF
+    from IPython import get_ipython
+    $(jupyter nbconvert ${NOTEBOOK} --stdout --to script)
+    ) | flake8 - --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  - |
+    (cat << EOF
+    from IPython import get_ipython
+    $(jupyter nbconvert ${NOTEBOOK} --stdout --to script)
+    ) | flake8 - --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 notifications:
   on_success: change
   on_failure: change  # `always` will be the setting once code changes slow down

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,26 @@
 group: travis_latest 
 language: python
 cache: pip
-matrix:
-  env:
-    - NOTEBOOK=01-introduction.ipynb
-    - NOTEBOOK=02-supervised-learning.ipynb
-    - NOTEBOOK=03-unsupervised-learning.ipynb
-    - NOTEBOOK=04-representing-data-feature-engineering.ipynb
-    - NOTEBOOK=05-model-evaluation-and-improvement.ipynb
-    - NOTEBOOK=06-algorithm-chains-and-pipelines.ipynb
-    - NOTEBOOK=07-working-with-text-data.ipynb
-    - NOTEBOOK=08-conclusion.ipynb
-  allow_failures:
-    - python: 2.7
-  include:
-    - python: 2.7
-    #- python: 3.4
-    #- python: 3.5
-    #- python: 3.6
-    - python: 3.7
-      dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
-      sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
+env:
+  - NOTEBOOK=01-introduction.ipynb
+  - NOTEBOOK=02-supervised-learning.ipynb
+  - NOTEBOOK=03-unsupervised-learning.ipynb
+  - NOTEBOOK=04-representing-data-feature-engineering.ipynb
+  - NOTEBOOK=05-model-evaluation-and-improvement.ipynb
+  - NOTEBOOK=06-algorithm-chains-and-pipelines.ipynb
+  - NOTEBOOK=07-working-with-text-data.ipynb
+  - NOTEBOOK=08-conclusion.ipynb
+  matrix:
+    allow_failures:
+      - python: 2.7
+    include:
+      - python: 2.7
+      #- python: 3.4
+      #- python: 3.5
+      #- python: 3.6
+      - python: 3.7
+        dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+        sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
 install:
   # - pip install -r requirements.txt
   - pip install flake8 jupyter

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,14 @@ script:
     (cat << EOF
     from IPython import get_ipython
     $(jupyter nbconvert ${NOTEBOOK} --stdout --to script)
-    EOF) | flake8 - --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    EOF
+    ) | flake8 - --count --select=E901,E999,F821,F822,F823 --show-source --statistics
   - |
     (cat << EOF
     from IPython import get_ipython
     $(jupyter nbconvert ${NOTEBOOK} --stdout --to script)
-    EOF) | flake8 - --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    EOF
+    ) | flake8 - --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 notifications:
   on_success: change
   on_failure: change  # `always` will be the setting once code changes slow down

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,26 +25,18 @@ before_script:
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
-  #- |
-  #  (cat << EOF
-  #  from IPython import get_ipython
-  #  $(jupyter nbconvert ${NOTEBOOK} --stdout --to script)
-  #  EOF
-  #  ) | flake8 - --count --select=E901,E999,F821,F822,F823 --show-source --statistics
-  #- |
-  #  (cat << EOF
-  #  from IPython import get_ipython
-  #  $(jupyter nbconvert ${NOTEBOOK} --stdout --to script)
-  #  EOF
-  #  ) | flake8 - --count --exit-zero --ignore=E402 --max-complexity=10 --max-line-length=88 --statistics
   - |
-    SCRIPT=$(cat << EOF
+    (cat << EOF
     from IPython import get_ipython
     $(jupyter nbconvert ${NOTEBOOK} --stdout --to script)
     EOF
-    )
-  - echo ${SCRIPT} | flake8 - --count --select=E901,E999,F821,F822,F823 --show-source --statistics
-  - echo ${SCRIPT} | flake8 - --count --exit-zero --ignore=E402 --max-complexity=10 --max-line-length=88 --statistics
+    ) | flake8 - --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  - |
+    (cat << EOF
+    from IPython import get_ipython
+    $(jupyter nbconvert ${NOTEBOOK} --stdout --to script)
+    EOF
+    ) | flake8 - --count --exit-zero --ignore=E402 --max-complexity=10 --max-line-length=88 --statistics
 notifications:
   on_success: change
   on_failure: change  # `always` will be the setting once code changes slow down

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,12 @@ script:
     (cat << EOF
     from IPython import get_ipython
     $(jupyter nbconvert ${NOTEBOOK} --stdout --to script)
-    ) | flake8 - --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    EOF) | flake8 - --count --select=E901,E999,F821,F822,F823 --show-source --statistics
   - |
     (cat << EOF
     from IPython import get_ipython
     $(jupyter nbconvert ${NOTEBOOK} --stdout --to script)
-    ) | flake8 - --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    EOF) | flake8 - --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 notifications:
   on_success: change
   on_failure: change  # `always` will be the setting once code changes slow down

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ script:
     from IPython import get_ipython
     $(jupyter nbconvert ${NOTEBOOK} --stdout --to script)
     EOF
-    ) | flake8 - --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    ) | flake8 - --count --exit-zero --ignore=E402 --max-complexity=10 --max-line-length=88 --statistics
 notifications:
   on_success: change
   on_failure: change  # `always` will be the setting once code changes slow down

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,15 @@
 group: travis_latest 
 language: python
 cache: pip
+env:
+  - NOTEBOOK=01-introduction.ipynb
+	- NOTEBOOK=02-supervised-learning.ipynb
+	- NOTEBOOK=03-unsupervised-learning.ipynb
+	- NOTEBOOK=04-representing-data-feature-engineering.ipynb
+	- NOTEBOOK=05-model-evaluation-and-improvement.ipynb
+	- NOTEBOOK=06-algorithm-chains-and-pipelines.ipynb
+	- NOTEBOOK=07-working-with-text-data.ipynb
+	- NOTEBOOK=08-conclusion.ipynb
 matrix:
   allow_failures:
     - python: 2.7
@@ -14,14 +23,14 @@ matrix:
       sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
 install:
   # - pip install -r requirements.txt
-  - pip install flake8
+  - pip install flake8 jupyter
 before_script:
   # stop the build if there are Python syntax errors or undefined names
   - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
-  - true  # add other tests here
+  - jupyter nbconvert ${NOTEBOOK} --stdout --to script | flake8 - --ignore=W391
 notifications:
   on_success: change
   on_failure: change  # `always` will be the setting once code changes slow down

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+group: travis_latest
+language: python
+cache: pip
+matrix:
+  allow_failures:
+    - python: 2.7
+  include:
+    - python: 2.7
+    #- python: 3.4
+    #- python: 3.5
+    #- python: 3.6
+    - python: 3.7
+      dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+      sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
+install:
+  # - pip install -r requirements.txt
+  - pip install flake8
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+  - true  # add other tests here
+notifications:
+  on_success: change
+  on_failure: change  # `always` will be the setting once code changes slow down

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,13 @@ language: python
 cache: pip
 env:
   - NOTEBOOK=01-introduction.ipynb
-	- NOTEBOOK=02-supervised-learning.ipynb
-	- NOTEBOOK=03-unsupervised-learning.ipynb
-	- NOTEBOOK=04-representing-data-feature-engineering.ipynb
-	- NOTEBOOK=05-model-evaluation-and-improvement.ipynb
-	- NOTEBOOK=06-algorithm-chains-and-pipelines.ipynb
-	- NOTEBOOK=07-working-with-text-data.ipynb
-	- NOTEBOOK=08-conclusion.ipynb
+  - NOTEBOOK=02-supervised-learning.ipynb
+  - NOTEBOOK=03-unsupervised-learning.ipynb
+  - NOTEBOOK=04-representing-data-feature-engineering.ipynb
+  - NOTEBOOK=05-model-evaluation-and-improvement.ipynb
+  - NOTEBOOK=06-algorithm-chains-and-pipelines.ipynb
+  - NOTEBOOK=07-working-with-text-data.ipynb
+  - NOTEBOOK=08-conclusion.ipynb
 matrix:
   allow_failures:
     - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,18 +25,26 @@ before_script:
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
+  #- |
+  #  (cat << EOF
+  #  from IPython import get_ipython
+  #  $(jupyter nbconvert ${NOTEBOOK} --stdout --to script)
+  #  EOF
+  #  ) | flake8 - --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  #- |
+  #  (cat << EOF
+  #  from IPython import get_ipython
+  #  $(jupyter nbconvert ${NOTEBOOK} --stdout --to script)
+  #  EOF
+  #  ) | flake8 - --count --exit-zero --ignore=E402 --max-complexity=10 --max-line-length=88 --statistics
   - |
-    (cat << EOF
+    SCRIPT=$(cat << EOF
     from IPython import get_ipython
     $(jupyter nbconvert ${NOTEBOOK} --stdout --to script)
     EOF
-    ) | flake8 - --count --select=E901,E999,F821,F822,F823 --show-source --statistics
-  - |
-    (cat << EOF
-    from IPython import get_ipython
-    $(jupyter nbconvert ${NOTEBOOK} --stdout --to script)
-    EOF
-    ) | flake8 - --count --exit-zero --ignore=E402 --max-complexity=10 --max-line-length=88 --statistics
+    )
+  - echo ${SCRIPT} | flake8 - --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  - echo ${SCRIPT} | flake8 - --count --exit-zero --ignore=E402 --max-complexity=10 --max-line-length=88 --statistics
 notifications:
   on_success: change
   on_failure: change  # `always` will be the setting once code changes slow down

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-group: travis_latest
+group: travis_latest 
 language: python
 cache: pip
 matrix:


### PR DESCRIPTION
Fixes #99

As discussed at https://github.com/amueller/introduction_to_ml_with_python/issues/96#issuecomment-430411669

In Travis CI, add a Python linting step that run [flake8](http://flake8.pycqa.org) tests in Travis CI to find syntax errors and undefined names.

__E901,E999,F821,F822,F823__ are the "_showstopper_" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree