### PR TITLE
Typo in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ For the text processing chapter, you need to download the English language model
 ## Submitting Errata
 
 If you have errata for the (e-)book, please submit them via the [O'Reilly Website](http://www.oreilly.com/catalog/errata.csp?isbn=0636920030515).
-You can submit fixed to the code as pull-requests here, but I'd appreciate it if you would also submit them there, as this repository doesn't hold the
+You can submit fixes to the code as pull-requests here, but I'd appreciate it if you would also submit them there, as this repository doesn't hold the
 "master notebooks".
 
 ![cover](cover.jpg)


### PR DESCRIPTION
A typo is a typo, even if it is in the errata section.