### PR TITLE
update to Preable and Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ the command ``pip install mglearn`` in your terminal or ``!pip install mglearn``
 
 
 ## Errata
+
+### Missing import
+
 Please note that the first print of the book is missing the following line when listing the assumed imports:
 
 ```python
@@ -34,6 +37,19 @@ from IPython.display import display
 ```
 Please add this line if you see an error involving ``display``.
 
+### Spacy download language name changed
+As of Spacy v3.0, the syntax is 
+
+```python
+python -m spacy download en_core_web_sm
+```
+
+### IPython.display.set_matplotlib_formats deprecated
+See https://github.com/fangohr/introduction-to-python-for-computational-science-and-engineering/issues/32
+
+[preamble.py](preamble.py) was adjusted to reflect the changes
+
+### Changes in sckit-learn from the first print
 
 The first print of the book used a function called ``plot_group_kfold``.
 This has been renamed to ``plot_label_kfold`` because of a rename in

--- a/preamble.py
+++ b/preamble.py
@@ -1,11 +1,22 @@
-from IPython.display import set_matplotlib_formats, display
+# Next is original line.
+# see https://github.com/fangohr/introduction-to-python-for-computational-science-and-engineering/issues/32
+#from IPython.display import set_matplotlib_formats, display
+from IPython.display import display
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
 import mglearn
 from cycler import cycler
 
-set_matplotlib_formats('pdf', 'png')
+# New block per above url on set_matplotlib_formats problem
+# settings for jupyter book: svg for html version, high-resolution png for pdf
+import matplotlib_inline.backend_inline
+# matplotlib_inline.backend_inline.set_matplotlib_formats('svg', 'png')
+# import matplotlib as mpl
+# mpl.rcParams['figure.dpi'] = 400
+
+matplotlib_inline.backend_inline.set_matplotlib_formats('pdf', 'png')
+#set_matplotlib_formats('pdf', 'png')
 plt.rcParams['savefig.dpi'] = 300
 plt.rcParams['image.cmap'] = "viridis"
 plt.rcParams['image.interpolation'] = "none"


### PR DESCRIPTION
Preamble: issue with deprecation: on set_matplotlib_formats
see code for the url where the issue is explained.

readme: added the topics to the errata section

Not submitted to O'Reilly since it is only on the github companion code.